### PR TITLE
Add secondary MIDI CC server

### DIFF
--- a/MOBILE_SETUP.md
+++ b/MOBILE_SETUP.md
@@ -8,6 +8,10 @@
    ```
    http://10.0.0.221:5001
    ```
+   or for the secondary controller
+   ```
+   http://10.0.0.221:5002
+   ```
 
 3. **For easier access, add to home screen:**
    - Tap the Share button in Safari
@@ -23,7 +27,7 @@
    - Set Input to "IAC Driver Bus 1"
 
 ## Network Access URL:
-**http://10.0.0.221:5001**
+**http://10.0.0.221:5001** (primary) or **http://10.0.0.221:5002** (secondary)
 
 ## Troubleshooting:
 
@@ -39,6 +43,7 @@
 
 ## Advanced Usage:
 You can also control faders via direct URL calls:
-- `http://10.0.0.221:5001/api/fader/1/100` - Set fader 1 to 100
-- `http://10.0.0.221:5001/api/fader/2/64` - Set fader 2 to 64
-- `http://10.0.0.221:5001/api/fader/3/0` - Set fader 3 to 0
+- `http://10.0.0.221:5001/api/fader/1/100` - Set fader 1 to 100 (CC1)
+- `http://10.0.0.221:5001/api/fader/2/64` - Set fader 2 to 64 (CC2)
+- `http://10.0.0.221:5001/api/fader/3/0` - Set fader 3 to 0 (CC3)
+- `http://10.0.0.221:5002/api/fader/1/127` - Set fader 1 to 127 (CC6)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ The MIDI port name can be configured in two ways:
    ```
 
 2. **Open the web interface:**
-   Navigate to `http://localhost:5000` in your web browser
+   Navigate to `http://localhost:5001` in your web browser for the primary
+   controller, or `http://localhost:5002` for the secondary one
 
 3. **Configure LUNA:**
    - In LUNA, go to **Preferences → Controllers**
@@ -99,18 +100,18 @@ Send GET requests to control faders programmatically:
 
 ```bash
 # Set fader 1 to value 100
-curl "http://localhost:5000/api/fader/1/100"
+curl "http://localhost:5001/api/fader/1/100"
 
 # Set fader 2 to value 64 (center position)
-curl "http://localhost:5000/api/fader/2/64"
+curl "http://localhost:5001/api/fader/2/64"
 
 # Set fader 3 to minimum (0)
-curl "http://localhost:5000/api/fader/3/0"
+curl "http://localhost:5001/api/fader/3/0"
 # Set Backing level (fader 4) to 80
-curl "http://localhost:5000/api/fader/4/80"
+curl "http://localhost:5001/api/fader/4/80"
 
 # Set Headphones level (fader 5) to 100
-curl "http://localhost:5000/api/fader/5/100"
+curl "http://localhost:5001/api/fader/5/100"
 ```
 
 **Response format:**
@@ -132,9 +133,9 @@ curl "http://localhost:5000/api/fader/5/100"
 - Ensure the controller type is set to "Mackie Control Universal"
 - Try restarting LUNA after configuring the controller
 
-**Web interface not loading:**
-- Check if another application is using port 5000
-- Try accessing `http://127.0.0.1:5000` instead of localhost
+-**Web interface not loading:**
+- Check if another application is using port 5001 or 5002
+- Try accessing `http://127.0.0.1:5001` instead of localhost
 - Verify the Flask server started without errors
 
 **Permission errors on Linux:**
@@ -142,7 +143,7 @@ curl "http://localhost:5000/api/fader/5/100"
 - Log out and back in for changes to take effect
 
 **Firewall blocking connections:**
-- Add an exception for Python or port 5000 in your firewall settings
+- Add an exception for Python or ports 5001 and 5002 in your firewall settings
 - On macOS, you may see a security prompt when first running the app
 
 ## Technical Details
@@ -152,7 +153,7 @@ curl "http://localhost:5000/api/fader/5/100"
   (pitch bend). Backing (Fader 4) uses MIDI CC4 and Headphones (Fader 5)
   uses MIDI CC5 on channel 0
 - **Value Encoding**: 14-bit values split into LSB and MSB bytes
-- **Port**: Web server runs on `http://localhost:5000`
+- **Port**: Web servers run on `http://localhost:5001` and `http://localhost:5002`
 
 ## License
 


### PR DESCRIPTION
## Summary
- host original controller on port 5001
- start a duplicate server on port 5002 sending MIDI CCs 6-10
- document new ports in README and mobile setup guide

## Testing
- `python -m py_compile app.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6883cd97a92c83258b6186e7564606e6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secondary web interface accessible on a new port, allowing independent control of a second set of faders with different MIDI mappings.
  * Both web interfaces can now be accessed simultaneously on separate ports.

* **Documentation**
  * Updated setup and usage instructions to reflect the addition of the secondary controller and new port numbers.
  * Clarified MIDI CC mappings and provided updated examples for both controllers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->