### PR TITLE
Add options panel and extended fader mapping

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -38,7 +38,12 @@
         <div class="main-content">
             <!-- Fader Area -->
             <div class="fader-area">
-                <div class="fader-contents">
+                <button class="options-button" id="options-button" title="Options">
+                    <svg viewBox="0 0 22 15" fill="none" stroke="#818181" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M1 1h20M1 7.5h20M1 14h20" />
+                    </svg>
+                </button>
+                <div class="fader-contents" id="fader-contents">
                     <div class="current-db-wrapper">
                         <div class="db-indicator">
                             <div class="db-value" id="db-value">0.0</div>
@@ -64,6 +69,20 @@
                         </div>
                         
                         <div class="spacer"></div>
+                    </div>
+                </div>
+                <div class="fx-controls" id="fx-controls">
+                    <div class="fx-fader">
+                        <label class="fx-label">Verb Dry/Wet</label>
+                        <input type="range" id="fx-verb" class="fx-slider" min="0" max="100" value="50" />
+                    </div>
+                    <div class="fx-fader">
+                        <label class="fx-label">Verb Decay</label>
+                        <input type="range" id="fx-decay" class="fx-slider" min="0" max="100" value="50" />
+                    </div>
+                    <div class="fx-fader">
+                        <label class="fx-label">Delay Dry/Wet</label>
+                        <input type="range" id="fx-delay" class="fx-slider" min="0" max="100" value="50" />
                     </div>
                 </div>
             </div>
@@ -123,7 +142,10 @@
             'Fader 2': 0,
             'Fader 3': 0,
             'Headphones': 0,
-            'Backing': 0
+            'Backing': 0,
+            'Verb Dry/Wet': 50,
+            'Verb Decay': 50,
+            'Delay Dry/Wet': 50
         };
 
         // Convert dB to MIDI value (0-127)
@@ -235,6 +257,10 @@
         async function sendMidiCommand(instrumentName, value) {
             // Determine endpoint based on selected control
             let endpoint = null;
+            const port = window.location.port;
+            const fxMapping = port === '5002'
+                ? { 'Verb Dry/Wet': 14, 'Verb Decay': 15, 'Delay Dry/Wet': 16 }
+                : { 'Verb Dry/Wet': 11, 'Verb Decay': 12, 'Delay Dry/Wet': 13 };
 
             if (instrumentName.startsWith('Fader')) {
                 const faderNumber = parseInt(instrumentName.split(' ')[1]);
@@ -243,6 +269,8 @@
                 endpoint = `/api/fader/4/${value}`;
             } else if (instrumentName === 'Headphones') {
                 endpoint = `/api/fader/5/${value}`;
+            } else if (instrumentName in fxMapping) {
+                endpoint = `/api/fader/${fxMapping[instrumentName]}/${value}`;
             } else {
                 return { status: 'ok', message: 'Control updated (no MIDI)' };
             }
@@ -325,6 +353,12 @@
             // Send MIDI command
             const midiValue = dbToMidi(newDb);
             sendMidiCommand(selectedInstrument, midiValue);
+        }
+
+        function handleFxChange(name, value) {
+            instrumentLevels[name] = value;
+            const midiValue = Math.round((value / 100) * 127);
+            sendMidiCommand(name, midiValue);
         }
 
         // Initialize fader drag functionality
@@ -611,11 +645,23 @@
         // Initialize the application when the page loads
         document.addEventListener('DOMContentLoaded', function() {
             console.log('LUNA MCU Virtual Controller initialized');
-            
+
             // Initialize all components
             initializeFader();
             initializeInstrumentButtons();
             initKeyboardShortcuts();
+
+            const optionsButton = document.getElementById('options-button');
+            const faderContents = document.getElementById('fader-contents');
+            const fxControls = document.getElementById('fx-controls');
+            optionsButton.addEventListener('click', () => {
+                const show = fxControls.classList.toggle('active');
+                optionsButton.classList.toggle('active', show);
+                faderContents.style.display = show ? 'none' : 'block';
+            });
+            document.getElementById('fx-verb').addEventListener('input', e => handleFxChange('Verb Dry/Wet', parseInt(e.target.value)));
+            document.getElementById('fx-decay').addEventListener('input', e => handleFxChange('Verb Decay', parseInt(e.target.value)));
+            document.getElementById('fx-delay').addEventListener('input', e => handleFxChange('Delay Dry/Wet', parseInt(e.target.value)));
             
             // Set initial fader position
             updateFaderPosition(0);

--- a/static/style.css
+++ b/static/style.css
@@ -443,6 +443,56 @@ body {
     display: none; /* Hide sending messages */
 }
 
+/* Options button and FX controls */
+.options-button {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+}
+.options-button:hover {
+    transform: scale(1.1);
+    opacity: 0.8;
+}
+.options-button.active {
+    opacity: 1;
+}
+
+.fx-controls {
+    position: absolute;
+    top: 19px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    gap: 20px;
+}
+.fx-controls.active {
+    display: flex;
+}
+.fx-fader {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    width: 70px;
+}
+.fx-label {
+    font-family: 'Futura', sans-serif;
+    font-size: 12px;
+    color: #383838;
+}
+.fx-slider {
+    writing-mode: bt-lr;
+    -webkit-appearance: slider-vertical;
+    width: 20px;
+    height: 150px;
+}
+
 /* Responsive design for iPhone */
 @media (max-width: 480px) {
     body {


### PR DESCRIPTION
## Summary
- add options button and FX controls panel in UI
- send FX fader updates via new API mappings
- map fader numbers 11-13 on port 5001 and 14-16 on port 5002
- extend back-end validation and routing for new fader numbers

## Testing
- `python -m py_compile app.py`
- `python test_midi.py` *(fails: libasound.so.2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6883e7f48810832589af27220fe160ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Options" button to toggle visibility of new effect controls for "Verb Dry/Wet," "Verb Decay," and "Delay Dry/Wet," each with adjustable sliders.
  * Expanded fader support to include additional fader numbers for both primary and secondary servers.
* **Improvements**
  * Unified and simplified error messages for invalid fader numbers.
  * Enhanced MIDI command handling to support new effect controls and fader mappings.
* **Style**
  * Introduced new styles for the options button and effect controls for improved user interface and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->