### PR TITLE
Fix fader area size on iPhone

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -142,7 +142,7 @@ body {
 /* Fader Area */
 .fader-area {
     background: #e8e8e8;
-    height: 469px;
+    min-height: 60vh;
     width: 100%;
     max-width: 400px; /* Constrain fader area width instead */
     margin: 0 auto; /* Center the fader area */
@@ -515,7 +515,7 @@ body {
 
 @media (max-width: 360px) {
     .fader-area {
-        height: 400px;
+        min-height: 60vh;
         width: 100%;
         max-width: 360px; /* Add max-width constraint */
         margin: 0 auto; /* Center the fader area */


### PR DESCRIPTION
## Summary
- make the fader area take up at least 60% of the screen
- apply the same rule for small devices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886548914b48325bf50ea1deec3b65e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the vertical sizing of the fader area to use a responsive minimum height based on the viewport, improving display across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->