### PR TITLE
feat: add configurable CC mappings

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,8 +7,17 @@
       "Drums",
       "Talkback",
       "Click"
+    ],
+    "cc": [
+      3,
+      4,
+      5,
+      6,
+      7
     ]
   },
+  "headphones_cc": 1,
+  "backing_cc": 2,
   "users": {
     "port_5001": "Fred",
     "port_5002": "Av"


### PR DESCRIPTION
## Summary
- allow setting CC numbers for headphones, backing, and individual tracks from the dashboard
- persist new CC settings in config and use them for MIDI messages
- display and edit CC values alongside track names

## Testing
- `python -m py_compile app.py dashboard.py`
- `python test_midi.py` *(fails: No module named 'mido')*


------
https://chatgpt.com/codex/tasks/task_e_68a7ae7eae648325a7deb808c8385526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Per‑track MIDI CC mapping, plus dedicated Headphones and Backing controls.
  - Dynamic multi‑fader support with validation across all tracks and masters.
  - UI now builds track blocks from your config and adds per‑track, Headphones, and Backing CC inputs.

- Improvements
  - Status displays reflect current config (track count/names, ports, user, last updated).
  - Safer defaults and better error handling if config is missing or invalid.
  - Automatic HTML fallback when static UI is unavailable.

- API Changes
  - Config save now validates CC fields and ranges; responses include clearer track names and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->