### PR TITLE
Add CC configuration controls for tracks and monitors

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,6 +9,11 @@
       "Click"
     ]
   },
+  "cc": {
+    "headphones": 1,
+    "backing": 2,
+    "tracks": [3, 4, 5, 6, 7]
+  },
   "users": {
     "port_5001": "Fred",
     "port_5002": "Av"


### PR DESCRIPTION
## Summary
- allow dashboard to edit MIDI CC numbers for headphones, backing, and each track
- use configured CC numbers in backend and provide endpoints for headphones/backing
- include default CC values in config and expose CC inputs in dashboard UI

## Testing
- `python -m py_compile app.py dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7ae7eae648325a7deb808c8385526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable MIDI CC mapping for headphones, backing, and each track/fader.
  * New HTTP endpoints to control headphones and backing via CC values.
  * UI updated to edit and display per-track CCs; track controls render dynamically based on configured track count and names.
  * Enhanced validation for CC data with clear error messages.

* **Chores**
  * Default and fallback configs now include a CC section; config loading normalizes CC lists to track count and improves error resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->