### PR TITLE
Dynamic track mapping from configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -163,6 +163,15 @@ def load_index_html(port=None):
     config = load_config()
     track_count = config['tracks']['count']
     track_names = config['tracks']['names']
+
+    # Build dynamic track-related structures based on track configuration
+    track_to_fader = {}
+    track_volumes = {}
+    for i in range(track_count):
+        name = track_names[i] if i < len(track_names) else f"Track {i+1}"
+        track_to_fader[name] = i + 1
+        track_volumes[name] = 0
+    active_fader_name = next(iter(track_to_fader)) if track_to_fader else ''
     
     # Determine user name based on port
     if port == PORT:
@@ -217,7 +226,12 @@ def load_index_html(port=None):
             pattern = r'<div class="available-tracks">.*?</div>\s*<div data-layer="Monitor Buttons"'
             replacement = f'<div class="available-tracks">\n{tracks_html}        </div>\n        <div data-layer="Monitor Buttons"'
             html_content = re.sub(pattern, replacement, html_content, flags=re.DOTALL)
-            
+
+            # Inject dynamic track configuration for JavaScript
+            html_content = html_content.replace('__TRACK_TO_FADER__', json.dumps(track_to_fader))
+            html_content = html_content.replace('__TRACK_VOLUMES__', json.dumps(track_volumes))
+            html_content = html_content.replace('__ACTIVE_FADER_NAME__', json.dumps(active_fader_name))
+
             return html_content
     except FileNotFoundError:
         # Generate dynamic HTML based on configuration

--- a/config.json
+++ b/config.json
@@ -1,17 +1,20 @@
 {
   "tracks": {
-    "count": 5,
+    "count": 8,
     "names": [
       "Vocals",
       "Guitar",
       "Drums",
-      "Talkback",
-      "Click"
+      "Snare",
+      "Click",
+      "Track 6",
+      "Track 7",
+      "Track 8"
     ]
   },
   "users": {
     "port_5001": "Fred",
     "port_5002": "Av"
   },
-  "last_updated": "2025-08-21T13:05:04.365403"
+  "last_updated": "2025-08-22T15:41:56.041997"
 }

--- a/static/index.html
+++ b/static/index.html
@@ -410,11 +410,7 @@
         let initialMouseY = 0;
         
         // Track volume state
-        let trackVolumes = {
-          'Guitar 1': 0,
-          'Guitar 2': 0,
-          'Bass': 0
-        };
+        let trackVolumes = __TRACK_VOLUMES__;
         
         // Monitor volume state
         let monitorVolumes = {
@@ -424,7 +420,7 @@
         
         // Current active fader type and name
         let activeFaderType = 'track'; // 'track' or 'monitor'
-        let activeFaderName = 'Guitar 1'; // tracks start with Guitar 1 selected
+        let activeFaderName = __ACTIVE_FADER_NAME__; // tracks start with first track selected
         
         let effectValues = {
           reverbDryWet: 50,
@@ -432,11 +428,7 @@
           delayDryWet: 50
         };
 
-        const trackToFader = {
-            'Guitar 1': 1,
-            'Guitar 2': 2,
-            'Bass': 3
-        };
+        const trackToFader = __TRACK_TO_FADER__;
         const monitorToFader = {
             'Backing': 4,
             'Headphones': 5


### PR DESCRIPTION
## Summary
- derive track-to-fader map, track volumes, and active fader name from config in `load_index_html`
- inject these values into `index.html` instead of hardcoded strings

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
import app, re
html = app.load_index_html()
print(html.find('Vocals')>=0)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a8c32ce0b48325b5e32ee50e30b22b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UI now initializes dynamically based on configured tracks: automatic mapping of track names to faders, per-track volume defaults, and the initial active track.
  * Frontend placeholders are populated at runtime, supporting any track count and names without hardcoded values.
  * Behavior applies whether serving a static or generated page; fader numbering remains 1-based and volumes default to 0.
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->