### PR TITLE
Dynamic track mapping from configuration

### DIFF
--- a/DASHBOARD_README.md
+++ b/DASHBOARD_README.md
@@ -5,9 +5,9 @@ A complete web-based control system for Universal Audio LUNA with a configuratio
 ## System Components
 
 ### Port 5001 - Main MCU Controller
-- Primary LUNA fader control using Mackie Control Universal protocol
-- Supports variable number of tracks (1-8) 
-- Uses pitch bend messages for faders 1-3, CC messages for additional tracks
+- Primary LUNA fader control using MIDI CC messages
+- Supports variable number of tracks (1-8)
+- Maps each fader number directly to the same CC number
 
 ### Port 5002 - Secondary CC Controller  
 - Alternative LUNA control using MIDI CC messages

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ A web-based virtual MIDI controller that implements Mackie Control Universal (MC
 This application creates a virtual MIDI output port and provides:
 - A Flask web server with HTTP endpoints for controlling five faders
 - A simple web interface with sliders that send MIDI commands to LUNA
-- Proper MCU protocol implementation using pitch-bend messages for track faders
-  and MIDI CC messages for Backing and Headphones levels
+- Uses MIDI control change (CC) messages for all faders
 
 ## Why use this?
 
@@ -89,9 +88,8 @@ The MIDI port name can be configured in two ways:
 ## Usage
 
 ### Web Interface
-- Use the sliders labeled **Fader 1**, **Fader 2**, **Fader 3**, **Backing**, and **Headphones**
-- Faders 1‑3 control the corresponding track faders in LUNA
-- The Backing and Headphones sliders send MIDI CC4 and CC5 messages
+- Use the sliders labeled with track names
+- Each fader sends a MIDI CC message where the control number matches its fader number (Fader 1 → CC1, etc.)
 - Values range from 0-127 (MIDI standard)
 - The current value is displayed next to each slider
 
@@ -107,10 +105,10 @@ curl "http://localhost:5001/api/fader/2/64"
 
 # Set fader 3 to minimum (0)
 curl "http://localhost:5001/api/fader/3/0"
-# Set Backing level (fader 4) to 80
+# Set fader 4 to 80
 curl "http://localhost:5001/api/fader/4/80"
 
-# Set Headphones level (fader 5) to 100
+# Set fader 5 to 100
 curl "http://localhost:5001/api/fader/5/100"
 ```
 
@@ -148,11 +146,9 @@ curl "http://localhost:5001/api/fader/5/100"
 
 ## Technical Details
 
-- **MIDI Protocol**: Implements MCU fader control using pitch-bend messages (0xE0 + channel)
-- **Channels**: Fader 1 = Channel 0, Fader 2 = Channel 1, Fader 3 = Channel 2
-  (pitch bend). Backing (Fader 4) uses MIDI CC4 and Headphones (Fader 5)
-  uses MIDI CC5 on channel 0
-- **Value Encoding**: 14-bit values split into LSB and MSB bytes
+- **MIDI Protocol**: Uses MIDI control change messages (CC) for all faders
+- **Channels**: CC messages are sent on channel 0 by default
+- **Value Encoding**: Standard 7-bit values (0-127)
 - **Port**: Web servers run on `http://localhost:5001` and `http://localhost:5002`
 
 ## License

--- a/static/index.html
+++ b/static/index.html
@@ -410,11 +410,7 @@
         let initialMouseY = 0;
         
         // Track volume state
-        let trackVolumes = {
-          'Guitar 1': 0,
-          'Guitar 2': 0,
-          'Bass': 0
-        };
+        let trackVolumes = __TRACK_VOLUMES__;
         
         // Monitor volume state
         let monitorVolumes = {
@@ -424,7 +420,7 @@
         
         // Current active fader type and name
         let activeFaderType = 'track'; // 'track' or 'monitor'
-        let activeFaderName = 'Guitar 1'; // tracks start with Guitar 1 selected
+        let activeFaderName = __ACTIVE_FADER_NAME__; // tracks start with first track selected
         
         let effectValues = {
           reverbDryWet: 50,
@@ -432,11 +428,7 @@
           delayDryWet: 50
         };
 
-        const trackToFader = {
-            'Guitar 1': 1,
-            'Guitar 2': 2,
-            'Bass': 3
-        };
+        const trackToFader = __TRACK_TO_FADER__;
         const monitorToFader = {
             'Backing': 4,
             'Headphones': 5

--- a/test_midi.py
+++ b/test_midi.py
@@ -17,11 +17,10 @@ def monitor_midi():
         
         while True:
             msg = midi_in.receive()
-            if msg.type == 'pitchwheel':
-                # Convert pitch value back to 0-127 range
-                fader_value = int((msg.pitch + 8192) / 16383 * 127)
-                print(f"Received MCU Fader: Channel {msg.channel} (Fader {msg.channel + 1}), "
-                      f"Pitch={msg.pitch}, Value={fader_value}")
+            if msg.type == 'control_change':
+                print(
+                    f"Received CC{msg.control} on channel {msg.channel}: Value={msg.value}"
+                )
             else:
                 print(f"Other MIDI message: {msg}")
                 


### PR DESCRIPTION
## Summary
- derive track-to-fader map, track volumes, and active fader name from config in `load_index_html`
- inject these values into `index.html` instead of hardcoded strings
- switch all faders to send MIDI control change messages and drop pitch-wheel handling
- update monitoring script and documentation for CC-based faders

## Testing
- `python -m py_compile app.py test_midi.py`
- `python - <<'PY'
import app, re
html = app.load_index_html()
match = re.search(r"trackToFader = (.*?);", html)
print('found:', bool(match))
if match:
    print('trackToFader:', match.group(1))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a8c32ce0b48325b5e32ee50e30b22b