### PR TITLE
Route CC fader controls to MIDI channel 2

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,10 @@ PORT = int(os.getenv('PORT', 5001))  # Main server port
 SECOND_PORT = int(os.getenv('PORT2', 5002))  # Secondary server port
 DEBUG = os.getenv('DEBUG', 'False').lower() == 'true'
 
+# MIDI channels (0-indexed: 0 = channel 1, 1 = channel 2)
+PRIMARY_MIDI_CHANNEL = 0
+SECONDARY_MIDI_CHANNEL = 1
+
 # Configuration file path (shared with dashboard)
 CONFIG_FILE = 'config.json'
 
@@ -308,8 +312,8 @@ def control_fader(fader_number, value):
             "message": "Invalid value. Must be between 0 and 127."
         }), 400
     
-    # Send MIDI CC message for all faders
-    success = send_cc_message(fader_number, value)
+    # Send MIDI CC message for all faders on the primary channel
+    success = send_cc_message(fader_number, value, channel=PRIMARY_MIDI_CHANNEL)
     
     if success:
         return jsonify({
@@ -344,7 +348,8 @@ def control_fader_cc(fader_number, value):
         }), 400
 
     cc_number = fader_number + 5  # Map 1-n -> 6-(n+5)
-    success = send_cc_message(cc_number, value)
+    # Use the secondary MIDI channel for CC control
+    success = send_cc_message(cc_number, value, channel=SECONDARY_MIDI_CHANNEL)
 
     if success:
         return jsonify({


### PR DESCRIPTION
## Summary
- add configurable MIDI channel constants for primary and secondary servers
- transmit secondary fader CC messages on MIDI channel 2
- use primary channel constant for main server faders

## Testing
- ⚠️ `pip install -r requirements.txt` *(python-rtmidi build failed)*
- ✅ `pip install mido==1.3.0`
- ⚠️ `pytest -q` *(no tests were collected)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e1a7b50c83258e61ec88428aa6bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MIDI control messages are now split across two channels for clearer routing.
  * Main fader CC messages are sent on MIDI channel 0; secondary CC controls are sent on MIDI channel 1.
  * Existing CC mappings remain unchanged; only the destination MIDI channel differs.
  * This separation enables easier integration with multi-channel MIDI setups, letting users independently route or filter primary fader controls and secondary CC controls without remapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->