### PR TITLE
Start fader CC assignments at 10

### DIFF
--- a/DASHBOARD_README.md
+++ b/DASHBOARD_README.md
@@ -7,11 +7,11 @@ A complete web-based control system for Universal Audio LUNA with a configuratio
 ### Port 5001 - Main MCU Controller
 - Primary LUNA fader control using MIDI CC messages
 - Supports variable number of tracks (1-8)
-- Maps each fader number directly to the same CC number
+- Maps faders to CC numbers starting at 10
 
-### Port 5002 - Secondary CC Controller  
+### Port 5002 - Secondary CC Controller
 - Alternative LUNA control using MIDI CC messages
-- Maps tracks to CC numbers 6-11 (for tracks 1-6)
+- Maps tracks to CC numbers starting at 10
 - Useful for different LUNA setups or DAW configurations
 
 ### Port 5003 - Configuration Dashboard 

--- a/MOBILE_SETUP.md
+++ b/MOBILE_SETUP.md
@@ -43,7 +43,7 @@
 
 ## Advanced Usage:
 You can also control faders via direct URL calls:
-- `http://10.0.0.221:5001/api/fader/1/100` - Set fader 1 to 100 (CC1)
-- `http://10.0.0.221:5001/api/fader/2/64` - Set fader 2 to 64 (CC2)
-- `http://10.0.0.221:5001/api/fader/3/0` - Set fader 3 to 0 (CC3)
-- `http://10.0.0.221:5002/api/fader/1/127` - Set fader 1 to 127 (CC6)
+- `http://10.0.0.221:5001/api/fader/1/100` - Set fader 1 to 100 (CC10)
+- `http://10.0.0.221:5001/api/fader/2/64` - Set fader 2 to 64 (CC11)
+- `http://10.0.0.221:5001/api/fader/3/0` - Set fader 3 to 0 (CC12)
+- `http://10.0.0.221:5002/api/fader/1/127` - Set fader 1 to 127 (CC10)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The MIDI port name can be configured in two ways:
 
 ### Web Interface
 - Use the sliders labeled with track names
-- Each fader sends a MIDI CC message where the control number matches its fader number (Fader 1 → CC1, etc.)
+- Each fader sends a MIDI CC message starting at CC10 (Fader 1 → CC10, Fader 2 → CC11, etc.)
 - Values range from 0-127 (MIDI standard)
 - The current value is displayed next to each slider
 

--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ HOST = '0.0.0.0'  # Listen on all network interfaces for mobile access
 PORT = int(os.getenv('PORT', 5001))  # Main server port
 SECOND_PORT = int(os.getenv('PORT2', 5002))  # Secondary server port
 DEBUG = os.getenv('DEBUG', 'False').lower() == 'true'
+FADER_CC_START = 10  # Base CC number for the first fader
 
 # Configuration file path (shared with dashboard)
 CONFIG_FILE = 'config.json'
@@ -313,8 +314,10 @@ def control_fader(fader_number, value):
             "message": "Invalid value. Must be between 0 and 127."
         }), 400
     
+    # Map fader numbers to sequential CC numbers starting at FADER_CC_START
+    cc_number = FADER_CC_START + fader_number - 1
     # Send MIDI CC message for all faders on channel 1 (MIDI channel 1)
-    success = send_cc_message(fader_number, value, channel=0, midi_port=midi_out)
+    success = send_cc_message(cc_number, value, channel=0, midi_port=midi_out)
     
     if success:
         return jsonify({
@@ -348,8 +351,10 @@ def control_fader_cc(fader_number, value):
             "message": "Invalid value. Must be between 0 and 127."
         }), 400
 
+    # Map fader numbers to sequential CC numbers starting at FADER_CC_START
+    cc_number = FADER_CC_START + fader_number - 1
     # Send on second MIDI port, channel 2
-    success = send_cc_message(fader_number, value, channel=1, midi_port=midi_out_cc)
+    success = send_cc_message(cc_number, value, channel=1, midi_port=midi_out_cc)
 
     if success:
         return jsonify({


### PR DESCRIPTION
## Summary
- offset fader MIDI CC mapping so the first fader transmits CC10 and subsequent faders increment sequentially
- document new CC mapping across README and mobile setup guide

## Testing
- `python -m py_compile app.py dashboard.py start_all.py test_midi.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e884f88483258673ffe563f430cb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated fader-to-MIDI CC mapping: Fader 1→CC10, Fader 2→CC11, etc., applied across all MIDI outputs and the web interface/API. Adjust any external mappings accordingly.
- Documentation
  - Revised guides to reflect the new CC mapping (Fader N→CC N+9).
  - Updated advanced usage examples to use CC10–CC12.
  - Improved header formatting for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->